### PR TITLE
fix: correct the CommonJS bundle path in main of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.0-development",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "typings": "dist/index.d.ts",
   "type": "module",
   "files": [


### PR DESCRIPTION
This commit fixes the`The path "route-typed" is imported in app/routes.ts but "route-typed" was not found in your node_modules. Did you forget to install it?` warning from build script.